### PR TITLE
Use `new Error()` when throwing

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -41,7 +41,7 @@ export function parse( text:string, options:ParseOptions ) {
 
 		// Start bracket
 		if ( c === C_BOPEN && !escaped ) {
-			if ( key === null ) throw( `Attempted to enter block without key at ${i}!` );
+			if ( key === null ) throw new Error( `Attempted to enter block without key at ${i}!` );
 			options.on_enter( key );
 			key = null;
 			continue;
@@ -49,7 +49,7 @@ export function parse( text:string, options:ParseOptions ) {
 
 		// End bracket
 		if ( c === C_BCLOSE && !escaped ) {
-			if ( key !== null && value === null ) throw( 'Encountered unpaired key!' );
+			if ( key !== null && value === null ) throw new Error( 'Encountered unpaired key!' );
 			else if ( value !== null ) options.on_key( key, value );
 			key = value = null;
 			options.on_exit();
@@ -62,7 +62,7 @@ export function parse( text:string, options:ParseOptions ) {
 
 			while (true) {
 				i = data.indexOf(C_QUOTE, i+1);
-				if (i === -1) throw( `Encountered unterminated quote starting at ${start-1}!` );
+				if (i === -1) throw new Error( `Encountered unterminated quote starting at ${start-1}!` );
 				if (no_escapes || data[i-1] !== C_ESCAPE) break;
 			}
 
@@ -89,7 +89,7 @@ export function parse( text:string, options:ParseOptions ) {
 			const start = i;
 			while (true) {
 				i = data.indexOf(42, i+1);
-				if ( i === -1 ) throw( `Encountered unterminated multiline comment starting at ${start}!` );
+				if ( i === -1 ) throw new Error( `Encountered unterminated multiline comment starting at ${start}!` );
 				if ( data[i+1] === 47 ) break;
 			}
 


### PR DESCRIPTION
~~This compilation process generates two directories in `dist` for ESM and CJS builds. Loosely followed this guide: https://transang.me/how-to-publish-a-hybrid-npm-package/~~

Uses `new Error()` whenever throwing errors, so caught errors are [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) objects.