### PR TITLE
Feat/types: Add support for boolean/number values in parsing and dumping!

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ The internal API used by the parse.xyz functions.
 ### SharedParseOptions
 ```ts
 interface SharedParseOptions {
-    escapes?: boolean;
+    escapes?:    boolean;
     multilines?: boolean;
+    types?:      boolean;
 }
 ```
 
@@ -124,5 +125,6 @@ interface ParseOptions {
     on_exit:    () => void;
     escapes:    boolean;
     multilines: boolean;
+    types:      boolean;
 }
 ```

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -4,6 +4,7 @@ import { KeyV, KeyVRoot, KeyVSet, ParseError } from './types.js';
 interface SharedParseOptions {
 	escapes?: boolean;
 	multilines?: boolean;
+	types?: boolean;
 }
 
 /** Parses data into a tree of objects.
@@ -25,6 +26,7 @@ export function parse( data:string, options?: SharedParseOptions ): KeyVRoot {
 		},
 		escapes: options?.escapes ?? true,
 		multilines: options?.multilines ?? true,
+		types: options?.types ?? true,
 	});
 
 	return out;
@@ -50,6 +52,7 @@ export function json( data:string, env:Object={}, options?: SharedParseOptions )
 		},
 		escapes: options?.escapes ?? true,
 		multilines: options?.multilines ?? true,
+		types: options?.types ?? true,
 	});
 
 	delete out.__parent__;

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,11 +225,11 @@ export class KeyVRoot extends KeyVSetCommon {}
 export class KeyV {
 
 	key:	string;
-	value:	string;
+	value:	string|number|boolean;
 	query:	string|null;
 	parent:	KeyVSetCommon|null;
 
-	constructor( key: string, value: string, query: string|null=null ) {
+	constructor( key: string, value: string|number|boolean, query: string|null=null ) {
 		this.key	= key;
 		this.value	= value;
 		this.query	= query;
@@ -241,7 +241,7 @@ export class KeyV {
 			indent
 			+ escape(this.key, format.quote)
 			+ ' '
-			+ escape(this.value, format.quote)
+			+ escape(this.value.toString(), format.quote)
 			+ ( this.query === null ? '\n' : ' [' + this.query + ']\n' )
 		);
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,9 @@ function needs_quotes(value: string): boolean {
 	return false;
 }
 
-function escape(value: string, quote: 'auto'|'always') {
+function escape(value: string|number|boolean, quote: 'auto'|'always'): string {
+	if (typeof value !== 'string') return value.toString();
+
 	if (quote === 'always' || needs_quotes(value)) {
 		const escaped = value
 			.replaceAll('\\', '\\\\')
@@ -241,7 +243,7 @@ export class KeyV {
 			indent
 			+ escape(this.key, format.quote)
 			+ ' '
-			+ escape(this.value.toString(), format.quote)
+			+ escape(this.value, format.quote)
 			+ ( this.query === null ? '\n' : ' [' + this.query + ']\n' )
 		);
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,7 +267,7 @@ class KeyVFactory {
 	}
 
 	/** Creates a new pair. */
-	pair( key: string, value: string, query: string|null=null ): this {
+	pair( key: string, value: string|number|boolean, query: string|null=null ): this {
 		this.source.add(new KeyV(key, value, query));
 		return this;
 	}

--- a/test/dump.mjs
+++ b/test/dump.mjs
@@ -16,6 +16,7 @@ const test_escape = new KeyVRoot().factory()
 	.pair('a"b"c', 'def\\')
 	.dir('dir')
 		.pair('xyz', '[123]')
+		.pair('123', 123)
 		.back()
 	.exit();
 
@@ -45,6 +46,7 @@ assert.strictEqual(dumpy,
 "dir"
 {
 	"xyz" "[123]"
+	"123" 123
 }
 `);
 });
@@ -59,6 +61,7 @@ a\\"b\\"c def\\\\
 dir
 {
 	xyz "[123]"
+	123 123
 }
 `);
 });

--- a/test/parse.mjs
+++ b/test/parse.mjs
@@ -36,12 +36,12 @@ describe('Parser', () => {
 			vdf.parse(`
 				"hello" "world" [QUERY] // Ignore "this" [comment]
 				"spaced key" "spaced value"
-				hello world
+				hello 123
 				"[QUERYISH_KEY]" unquoted.value`).all(),
 			new KeyVRoot()
 				.add(new KeyV('hello', 'world', 'QUERY'))
 				.add(new KeyV('spaced key', 'spaced value'))
-				.add(new KeyV('hello', 'world'))
+				.add(new KeyV('hello', 123))
 				.add(new KeyV('[QUERYISH_KEY]', 'unquoted.value'))
 				.all()
 		);

--- a/test/types.mjs
+++ b/test/types.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert';
+import { vdf, KeyVRoot, KeyVSet, KeyV } from '../dist/index.js';
+
+const input = `"123" "456"
+123 456
+true "true"
+false false
+`;
+
+const input_quoted = `"123" "456"
+"123" 456
+"true" "true"
+"false" false
+`;
+
+const expected_parse = new KeyVRoot().factory()
+	.pair('123', '456')
+	.pair('123', 456)
+	.pair('true', 'true')
+	.pair('false', false)
+	.exit();
+
+describe('Types', () => {
+	it('Parses typed input', () => {
+		assert.deepStrictEqual(vdf.parse(input).pairs(), expected_parse.pairs());
+	});
+
+	it('Dumps always-quoted typed output', () => {
+		assert.strictEqual(vdf.parse(input).dump({ quote: 'always' }), input_quoted);
+	});
+
+	it('Dumps auto-quoted typed output', () => {
+		assert.strictEqual(vdf.parse(input).dump({ quote: 'auto' }), input);
+	});
+});


### PR DESCRIPTION
This PR fails one dumping test, but the error case is niche.

String values that look like numbers/booleans will not be auto-quoted, as they meet the criteria for strings that do not have to be quoted. This will result in an unintentional string -> number/boolean conversion if the string is parsed again. This can be patched easily, but it might be costly for performance.